### PR TITLE
vdd_set stability enhancements

### DIFF
--- a/main.py
+++ b/main.py
@@ -90,4 +90,5 @@ print(np.average(result))
 if(smu_enabled):
     smu.output_disable()
 
-
+rtt.disconnect_from_emu()
+rtt.close()


### PR DESCRIPTION
Limit the range of values that is accepted by vdd_set to [2.1V, 3.6V]
and add a short delay between calls to write_stuffed to help prevent
the connection to the emulator from stalling.

Also add calls to disconnect_from_emu and close to bottom of main.py.